### PR TITLE
render badges and opticon as markdown

### DIFF
--- a/notebook.ipynb
+++ b/notebook.ipynb
@@ -3,9 +3,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    },
     "tags": [
      "target/urban",
      "theme/exploration",
@@ -15,6 +12,12 @@
    },
    "source": [
     "# Met Office UKV high-resolution atmosphere model data\n",
+    "\n",
+    "{opticon}`tag`\n",
+    "{bdg-primary}`Urban`\n",
+    "{bdg-secondary}`Exploration`\n",
+    "{bdg-warning}`Regular`\n",
+    "{bdg-info}`Python`\n",
     "\n",
     ":::{eval-rst}\n",
     ":opticon:`tag`\n",


### PR DESCRIPTION
- render badges and opticon as markdown instead of RST